### PR TITLE
Add SQLite schema, connection, and CRUD models

### DIFF
--- a/src/db/connection.py
+++ b/src/db/connection.py
@@ -1,0 +1,19 @@
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+
+BASE_DIR = Path(__file__).resolve().parent
+SCHEMA_FILE = BASE_DIR / "schema.sql"
+DEFAULT_DB = BASE_DIR / "agri_manager.db"
+
+def get_connection(db_path: str | Path = DEFAULT_DB) -> sqlite3.Connection:
+    """Return a SQLite connection and initialize schema if database is new."""
+    db_path = Path(db_path)
+    initialize = not db_path.exists()
+    conn = sqlite3.connect(db_path)
+    conn.row_factory = sqlite3.Row
+    if initialize and SCHEMA_FILE.exists():
+        with open(SCHEMA_FILE, "r", encoding="utf-8") as f:
+            conn.executescript(f.read())
+    return conn

--- a/src/db/schema.sql
+++ b/src/db/schema.sql
@@ -1,0 +1,54 @@
+CREATE TABLE IF NOT EXISTS fields (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    name TEXT NOT NULL,
+    area REAL,
+    crop_type TEXT,
+    created_at TEXT DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE TABLE IF NOT EXISTS treatments (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    field_id INTEGER,
+    treatment_type TEXT,
+    treatment_date TEXT,
+    product TEXT,
+    quantity REAL,
+    cost REAL,
+    notes TEXT,
+    FOREIGN KEY(field_id) REFERENCES fields(id)
+);
+
+CREATE TABLE IF NOT EXISTS incomes (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    field_id INTEGER,
+    source TEXT,
+    amount REAL NOT NULL,
+    income_date TEXT,
+    notes TEXT,
+    FOREIGN KEY(field_id) REFERENCES fields(id)
+);
+
+CREATE TABLE IF NOT EXISTS expenses (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    field_id INTEGER,
+    description TEXT,
+    amount REAL NOT NULL,
+    expense_date TEXT,
+    notes TEXT,
+    FOREIGN KEY(field_id) REFERENCES fields(id)
+);
+
+CREATE TABLE IF NOT EXISTS inventory (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    item_name TEXT NOT NULL,
+    quantity REAL NOT NULL,
+    unit TEXT,
+    cost REAL,
+    expiration_date TEXT
+);
+
+CREATE TABLE IF NOT EXISTS dropdown_lists (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    category TEXT NOT NULL,
+    value TEXT NOT NULL
+);

--- a/src/models/dropdown_lists.py
+++ b/src/models/dropdown_lists.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+from typing import Any, Dict, List, Optional
+
+from src.db.connection import get_connection
+
+
+def create_dropdown_item(category: str, value: str) -> int:
+    conn = get_connection()
+    cur = conn.cursor()
+    cur.execute(
+        "INSERT INTO dropdown_lists (category, value) VALUES (?, ?)",
+        (category, value),
+    )
+    conn.commit()
+    item_id = cur.lastrowid
+    conn.close()
+    return item_id
+
+
+def get_dropdown_items(category: Optional[str] = None) -> List[Dict[str, Any]]:
+    conn = get_connection()
+    if category is not None:
+        cur = conn.execute(
+            "SELECT * FROM dropdown_lists WHERE category = ?", (category,)
+        )
+    else:
+        cur = conn.execute("SELECT * FROM dropdown_lists")
+    rows = [dict(row) for row in cur.fetchall()]
+    conn.close()
+    return rows
+
+
+def get_dropdown_item(item_id: int) -> Optional[Dict[str, Any]]:
+    conn = get_connection()
+    cur = conn.execute("SELECT * FROM dropdown_lists WHERE id = ?", (item_id,))
+    row = cur.fetchone()
+    conn.close()
+    return dict(row) if row else None
+
+
+def update_dropdown_item(
+    item_id: int,
+    category: Optional[str] = None,
+    value: Optional[str] = None,
+) -> None:
+    conn = get_connection()
+    fields = {"category": category, "value": value}
+    updates = [f"{k} = ?" for k, v in fields.items() if v is not None]
+    values = [v for v in fields.values() if v is not None]
+    if updates:
+        values.append(item_id)
+        conn.execute(
+            f"UPDATE dropdown_lists SET {', '.join(updates)} WHERE id = ?",
+            values,
+        )
+        conn.commit()
+    conn.close()
+
+
+def delete_dropdown_item(item_id: int) -> None:
+    conn = get_connection()
+    conn.execute("DELETE FROM dropdown_lists WHERE id = ?", (item_id,))
+    conn.commit()
+    conn.close()

--- a/src/models/expenses.py
+++ b/src/models/expenses.py
@@ -1,0 +1,78 @@
+from __future__ import annotations
+
+from typing import Any, Dict, List, Optional
+
+from src.db.connection import get_connection
+
+
+def create_expense(
+    field_id: int,
+    description: str,
+    amount: float,
+    expense_date: str,
+    notes: Optional[str] = None,
+) -> int:
+    conn = get_connection()
+    cur = conn.cursor()
+    cur.execute(
+        """
+        INSERT INTO expenses (field_id, description, amount, expense_date, notes)
+        VALUES (?, ?, ?, ?, ?)
+        """,
+        (field_id, description, amount, expense_date, notes),
+    )
+    conn.commit()
+    expense_id = cur.lastrowid
+    conn.close()
+    return expense_id
+
+
+def get_expenses() -> List[Dict[str, Any]]:
+    conn = get_connection()
+    cur = conn.execute("SELECT * FROM expenses")
+    rows = [dict(row) for row in cur.fetchall()]
+    conn.close()
+    return rows
+
+
+def get_expense(expense_id: int) -> Optional[Dict[str, Any]]:
+    conn = get_connection()
+    cur = conn.execute("SELECT * FROM expenses WHERE id = ?", (expense_id,))
+    row = cur.fetchone()
+    conn.close()
+    return dict(row) if row else None
+
+
+def update_expense(
+    expense_id: int,
+    field_id: Optional[int] = None,
+    description: Optional[str] = None,
+    amount: Optional[float] = None,
+    expense_date: Optional[str] = None,
+    notes: Optional[str] = None,
+) -> None:
+    conn = get_connection()
+    fields = {
+        "field_id": field_id,
+        "description": description,
+        "amount": amount,
+        "expense_date": expense_date,
+        "notes": notes,
+    }
+    updates = [f"{k} = ?" for k, v in fields.items() if v is not None]
+    values = [v for v in fields.values() if v is not None]
+    if updates:
+        values.append(expense_id)
+        conn.execute(
+            f"UPDATE expenses SET {', '.join(updates)} WHERE id = ?",
+            values,
+        )
+        conn.commit()
+    conn.close()
+
+
+def delete_expense(expense_id: int) -> None:
+    conn = get_connection()
+    conn.execute("DELETE FROM expenses WHERE id = ?", (expense_id,))
+    conn.commit()
+    conn.close()

--- a/src/models/fields.py
+++ b/src/models/fields.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+
+from typing import Any, Dict, List, Optional
+
+from src.db.connection import get_connection
+
+
+def create_field(name: str, area: Optional[float] = None, crop_type: Optional[str] = None) -> int:
+    conn = get_connection()
+    cur = conn.cursor()
+    cur.execute(
+        "INSERT INTO fields (name, area, crop_type) VALUES (?, ?, ?)",
+        (name, area, crop_type),
+    )
+    conn.commit()
+    field_id = cur.lastrowid
+    conn.close()
+    return field_id
+
+
+def get_fields() -> List[Dict[str, Any]]:
+    conn = get_connection()
+    cur = conn.execute("SELECT * FROM fields")
+    rows = [dict(row) for row in cur.fetchall()]
+    conn.close()
+    return rows
+
+
+def get_field(field_id: int) -> Optional[Dict[str, Any]]:
+    conn = get_connection()
+    cur = conn.execute("SELECT * FROM fields WHERE id = ?", (field_id,))
+    row = cur.fetchone()
+    conn.close()
+    return dict(row) if row else None
+
+
+def update_field(
+    field_id: int,
+    name: Optional[str] = None,
+    area: Optional[float] = None,
+    crop_type: Optional[str] = None,
+) -> None:
+    conn = get_connection()
+    fields = {"name": name, "area": area, "crop_type": crop_type}
+    updates = [f"{k} = ?" for k, v in fields.items() if v is not None]
+    values = [v for v in fields.values() if v is not None]
+    if updates:
+        values.append(field_id)
+        conn.execute(f"UPDATE fields SET {', '.join(updates)} WHERE id = ?", values)
+        conn.commit()
+    conn.close()
+
+
+def delete_field(field_id: int) -> None:
+    conn = get_connection()
+    conn.execute("DELETE FROM fields WHERE id = ?", (field_id,))
+    conn.commit()
+    conn.close()

--- a/src/models/incomes.py
+++ b/src/models/incomes.py
@@ -1,0 +1,78 @@
+from __future__ import annotations
+
+from typing import Any, Dict, List, Optional
+
+from src.db.connection import get_connection
+
+
+def create_income(
+    field_id: int,
+    source: str,
+    amount: float,
+    income_date: str,
+    notes: Optional[str] = None,
+) -> int:
+    conn = get_connection()
+    cur = conn.cursor()
+    cur.execute(
+        """
+        INSERT INTO incomes (field_id, source, amount, income_date, notes)
+        VALUES (?, ?, ?, ?, ?)
+        """,
+        (field_id, source, amount, income_date, notes),
+    )
+    conn.commit()
+    income_id = cur.lastrowid
+    conn.close()
+    return income_id
+
+
+def get_incomes() -> List[Dict[str, Any]]:
+    conn = get_connection()
+    cur = conn.execute("SELECT * FROM incomes")
+    rows = [dict(row) for row in cur.fetchall()]
+    conn.close()
+    return rows
+
+
+def get_income(income_id: int) -> Optional[Dict[str, Any]]:
+    conn = get_connection()
+    cur = conn.execute("SELECT * FROM incomes WHERE id = ?", (income_id,))
+    row = cur.fetchone()
+    conn.close()
+    return dict(row) if row else None
+
+
+def update_income(
+    income_id: int,
+    field_id: Optional[int] = None,
+    source: Optional[str] = None,
+    amount: Optional[float] = None,
+    income_date: Optional[str] = None,
+    notes: Optional[str] = None,
+) -> None:
+    conn = get_connection()
+    fields = {
+        "field_id": field_id,
+        "source": source,
+        "amount": amount,
+        "income_date": income_date,
+        "notes": notes,
+    }
+    updates = [f"{k} = ?" for k, v in fields.items() if v is not None]
+    values = [v for v in fields.values() if v is not None]
+    if updates:
+        values.append(income_id)
+        conn.execute(
+            f"UPDATE incomes SET {', '.join(updates)} WHERE id = ?",
+            values,
+        )
+        conn.commit()
+    conn.close()
+
+
+def delete_income(income_id: int) -> None:
+    conn = get_connection()
+    conn.execute("DELETE FROM incomes WHERE id = ?", (income_id,))
+    conn.commit()
+    conn.close()

--- a/src/models/inventory.py
+++ b/src/models/inventory.py
@@ -1,0 +1,78 @@
+from __future__ import annotations
+
+from typing import Any, Dict, List, Optional
+
+from src.db.connection import get_connection
+
+
+def create_item(
+    item_name: str,
+    quantity: float,
+    unit: str,
+    cost: Optional[float] = None,
+    expiration_date: Optional[str] = None,
+) -> int:
+    conn = get_connection()
+    cur = conn.cursor()
+    cur.execute(
+        """
+        INSERT INTO inventory (item_name, quantity, unit, cost, expiration_date)
+        VALUES (?, ?, ?, ?, ?)
+        """,
+        (item_name, quantity, unit, cost, expiration_date),
+    )
+    conn.commit()
+    item_id = cur.lastrowid
+    conn.close()
+    return item_id
+
+
+def get_items() -> List[Dict[str, Any]]:
+    conn = get_connection()
+    cur = conn.execute("SELECT * FROM inventory")
+    rows = [dict(row) for row in cur.fetchall()]
+    conn.close()
+    return rows
+
+
+def get_item(item_id: int) -> Optional[Dict[str, Any]]:
+    conn = get_connection()
+    cur = conn.execute("SELECT * FROM inventory WHERE id = ?", (item_id,))
+    row = cur.fetchone()
+    conn.close()
+    return dict(row) if row else None
+
+
+def update_item(
+    item_id: int,
+    item_name: Optional[str] = None,
+    quantity: Optional[float] = None,
+    unit: Optional[str] = None,
+    cost: Optional[float] = None,
+    expiration_date: Optional[str] = None,
+) -> None:
+    conn = get_connection()
+    fields = {
+        "item_name": item_name,
+        "quantity": quantity,
+        "unit": unit,
+        "cost": cost,
+        "expiration_date": expiration_date,
+    }
+    updates = [f"{k} = ?" for k, v in fields.items() if v is not None]
+    values = [v for v in fields.values() if v is not None]
+    if updates:
+        values.append(item_id)
+        conn.execute(
+            f"UPDATE inventory SET {', '.join(updates)} WHERE id = ?",
+            values,
+        )
+        conn.commit()
+    conn.close()
+
+
+def delete_item(item_id: int) -> None:
+    conn = get_connection()
+    conn.execute("DELETE FROM inventory WHERE id = ?", (item_id,))
+    conn.commit()
+    conn.close()

--- a/src/models/treatments.py
+++ b/src/models/treatments.py
@@ -1,0 +1,84 @@
+from __future__ import annotations
+
+from typing import Any, Dict, List, Optional
+
+from src.db.connection import get_connection
+
+
+def create_treatment(
+    field_id: int,
+    treatment_type: str,
+    treatment_date: str,
+    product: str,
+    quantity: Optional[float] = None,
+    cost: Optional[float] = None,
+    notes: Optional[str] = None,
+) -> int:
+    conn = get_connection()
+    cur = conn.cursor()
+    cur.execute(
+        """
+        INSERT INTO treatments (field_id, treatment_type, treatment_date, product, quantity, cost, notes)
+        VALUES (?, ?, ?, ?, ?, ?, ?)
+        """,
+        (field_id, treatment_type, treatment_date, product, quantity, cost, notes),
+    )
+    conn.commit()
+    treatment_id = cur.lastrowid
+    conn.close()
+    return treatment_id
+
+
+def get_treatments() -> List[Dict[str, Any]]:
+    conn = get_connection()
+    cur = conn.execute("SELECT * FROM treatments")
+    rows = [dict(row) for row in cur.fetchall()]
+    conn.close()
+    return rows
+
+
+def get_treatment(treatment_id: int) -> Optional[Dict[str, Any]]:
+    conn = get_connection()
+    cur = conn.execute("SELECT * FROM treatments WHERE id = ?", (treatment_id,))
+    row = cur.fetchone()
+    conn.close()
+    return dict(row) if row else None
+
+
+def update_treatment(
+    treatment_id: int,
+    field_id: Optional[int] = None,
+    treatment_type: Optional[str] = None,
+    treatment_date: Optional[str] = None,
+    product: Optional[str] = None,
+    quantity: Optional[float] = None,
+    cost: Optional[float] = None,
+    notes: Optional[str] = None,
+) -> None:
+    conn = get_connection()
+    fields = {
+        "field_id": field_id,
+        "treatment_type": treatment_type,
+        "treatment_date": treatment_date,
+        "product": product,
+        "quantity": quantity,
+        "cost": cost,
+        "notes": notes,
+    }
+    updates = [f"{k} = ?" for k, v in fields.items() if v is not None]
+    values = [v for v in fields.values() if v is not None]
+    if updates:
+        values.append(treatment_id)
+        conn.execute(
+            f"UPDATE treatments SET {', '.join(updates)} WHERE id = ?",
+            values,
+        )
+        conn.commit()
+    conn.close()
+
+
+def delete_treatment(treatment_id: int) -> None:
+    conn = get_connection()
+    conn.execute("DELETE FROM treatments WHERE id = ?", (treatment_id,))
+    conn.commit()
+    conn.close()


### PR DESCRIPTION
## Summary
- define database schema for fields, treatments, incomes, expenses, inventory, and dropdown list tables
- provide connection helper that initializes the SQLite database from the schema
- implement CRUD model modules for each entity using the shared connection

## Testing
- `python -m py_compile $(find src -name '*.py')`
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68924570aa4c8330a0bdbbf4b0c1ebfd